### PR TITLE
ci: only deploy on push to main, not on PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ jobs:
           path: './out'
 
   deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Fixes deploy job to only run on push to main branch, not on pull requests. This prevents deploy failures on PR branches while still running build checks.