### PR TITLE
ci: improve dependabot and github actions configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,4 +18,21 @@ updates:
         dependency-type: "production"
       development-dependencies:
         dependency-type: "development"
+    # Ignore major version updates for @types/node to avoid breaking changes
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "automated"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,6 +35,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+        continue-on-error: true
+
       - name: Build
         run: npm run build
         env:
@@ -45,7 +50,7 @@ jobs:
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: './out'
 


### PR DESCRIPTION
## Forbedringer

### Dependabot
- ✅ Tilføjet  package-ecosystem, så Dependabot også opdaterer GitHub Actions automatisk
- ✅ Ignorer major updates for  for at undgå breaking changes

### GitHub Actions
- ✅ Opdateret  fra v3 til v4
- ✅ Tilføjet lint step (med continue-on-error)
- ✅ Tilføjet timeout på 10 minutter til build jobbet