### PR TITLE
feat: update to custom domain madebyhuman.iamjarl.com

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,8 +43,7 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: production
-          BASE_PATH: /madebyhuman
-          NEXT_PUBLIC_BASE_PATH: /madebyhuman
+          NEXT_PUBLIC_SITE_ORIGIN: https://madebyhuman.iamjarl.com
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Co-created with AI](https://jarllyng.github.io/madebyhuman/badges/co-created-white.svg)
+![Co-created with AI](https://madebyhuman.iamjarl.com/badges/co-created-white.svg)
 
 # Made by Human
 
@@ -81,11 +81,11 @@ The website provides copy-paste embed code for each badge variant (Markdown, HTM
 
 #### Badge URLs
 
-All badges are hosted at: `https://jarllyng.github.io/madebyhuman/badges/[filename]-[variant].svg`
+All badges are hosted at: `https://madebyhuman.iamjarl.com/badges/[filename]-[variant].svg`
 
 Examples:
-- `https://jarllyng.github.io/madebyhuman/badges/made-white.svg`
-- `https://jarllyng.github.io/madebyhuman/badges/co-created-black.svg`
+- `https://madebyhuman.iamjarl.com/badges/made-white.svg`
+- `https://madebyhuman.iamjarl.com/badges/co-created-black.svg`
 
 ---
 
@@ -145,7 +145,7 @@ The website is automatically deployed to **GitHub Pages** using GitHub Actions. 
 
 ### Live Site
 
-The website is available at: **https://jarllyng.github.io/madebyhuman/**
+The website is available at: **https://madebyhuman.iamjarl.com/**
 
 ### Deployment Process
 
@@ -156,7 +156,7 @@ The website is available at: **https://jarllyng.github.io/madebyhuman/**
 
 ### Build Configuration
 
-- **Base Path**: `/madebyhuman` (configured for GitHub Pages subdirectory)
+- **Custom Domain**: `madebyhuman.iamjarl.com`
 - **Output**: Static export (`output: 'export'`)
 - **Images**: Unoptimized (required for static export)
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,16 +1,11 @@
 import type { NextConfig } from "next";
 
-// Use NEXT_PUBLIC_BASE_PATH for consistency with client-side code
-// Default to empty for local dev, /madebyhuman for production builds
-const basePath = process.env.NEXT_PUBLIC_BASE_PATH || (process.env.NODE_ENV === 'production' ? '/madebyhuman' : '');
-
+// With custom domain (madebyhuman.iamjarl.com), we no longer need basePath
 const nextConfig: NextConfig = {
   output: 'export',
   images: {
     unoptimized: true,
   },
-  basePath: basePath,
-  assetPrefix: basePath,
 };
 
 export default nextConfig;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://jarllyng.github.io/madebyhuman/sitemap.xml
+Sitemap: https://madebyhuman.iamjarl.com/sitemap.xml
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://jarllyng.github.io/madebyhuman/</loc>
-    <lastmod>2024-12-19</lastmod>
+    <loc>https://madebyhuman.iamjarl.com/</loc>
+    <lastmod>2025-12-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -1,29 +1,13 @@
 /**
- * Centralized configuration for base path and site origin
+ * Centralized configuration for site origin
  * This ensures consistency across all URL generation (downloads, embeds, metadata)
+ * 
+ * With custom domain (madebyhuman.iamjarl.com), we no longer need basePath
  */
-
-// Get base path from environment (server-side safe)
-export function getBasePath(): string {
-  return process.env.NEXT_PUBLIC_BASE_PATH || '';
-}
-
-// Get base path from environment or detect from window location (client-side)
-export function getBasePathClient(): string {
-  if (typeof window !== 'undefined') {
-    const pathname = window.location.pathname;
-    // Check if we're on GitHub Pages (pathname starts with /madebyhuman)
-    if (pathname.startsWith('/madebyhuman')) {
-      return '/madebyhuman';
-    }
-  }
-  // Fallback to environment variable
-  return process.env.NEXT_PUBLIC_BASE_PATH || '';
-}
 
 // Get site origin (domain + protocol) - server-side safe
 export function getSiteOrigin(): string {
-  return process.env.NEXT_PUBLIC_SITE_ORIGIN || 'https://jarllyng.github.io';
+  return process.env.NEXT_PUBLIC_SITE_ORIGIN || 'https://madebyhuman.iamjarl.com';
 }
 
 // Get site origin (client-side)
@@ -34,24 +18,19 @@ export function getSiteOriginClient(): string {
   return getSiteOrigin();
 }
 
-// Get full base URL (origin + base path) - server-side safe
+// Get full base URL (origin) - server-side safe
 export function getBaseUrl(): string {
-  const origin = getSiteOrigin();
-  const basePath = getBasePath();
-  return `${origin}${basePath}`;
+  return getSiteOrigin();
 }
 
 // Get full base URL (client-side)
 export function getBaseUrlClient(): string {
-  const origin = getSiteOriginClient();
-  const basePath = getBasePathClient();
-  return `${origin}${basePath}`;
+  return getSiteOriginClient();
 }
 
 // Generate badge URL (for downloads and embeds) - client-side
 export function getBadgeUrl(filename: string, variant: 'white' | 'black'): string {
-  const basePath = getBasePathClient();
-  return `${basePath}/badges/${filename}-${variant}.svg`;
+  return `/badges/${filename}-${variant}.svg`;
 }
 
 // Generate full badge URL with origin (for embed codes that need absolute URLs) - client-side

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Script from "next/script";
-import { getBasePath, getSiteOrigin, getBaseUrl } from "./config";
+import { getSiteOrigin, getBaseUrl } from "./config";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -15,7 +15,6 @@ const geistMono = Geist_Mono({
 });
 
 // Get configuration values for metadata (server-side)
-const basePath = getBasePath();
 const siteOrigin = getSiteOrigin();
 const baseUrl = getBaseUrl();
 
@@ -43,13 +42,13 @@ export const metadata: Metadata = {
   },
   icons: {
     icon: [
-      { url: `${basePath}/favicon.ico`, sizes: 'any' },
-      { url: `${basePath}/icon.svg`, type: 'image/svg+xml' },
-      { url: `${basePath}/android-chrome-192x192.png`, sizes: '192x192', type: 'image/png' },
-      { url: `${basePath}/android-chrome-512x512.png`, sizes: '512x512', type: 'image/png' },
+      { url: `/favicon.ico`, sizes: 'any' },
+      { url: `/icon.svg`, type: 'image/svg+xml' },
+      { url: `/android-chrome-192x192.png`, sizes: '192x192', type: 'image/png' },
+      { url: `/android-chrome-512x512.png`, sizes: '512x512', type: 'image/png' },
     ],
     apple: [
-      { url: `${basePath}/apple-touch-icon.png`, sizes: '180x180', type: 'image/png' },
+      { url: `/apple-touch-icon.png`, sizes: '180x180', type: 'image/png' },
     ],
   },
   openGraph: {
@@ -61,7 +60,7 @@ export const metadata: Metadata = {
     locale: "en_US",
     images: [
       {
-        url: `${basePath}/og-image.png`,
+        url: `/og-image.png`,
         width: 1200,
         height: 630,
         alt: "Made by Human - A positive movement celebrating human creativity",
@@ -72,7 +71,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Made by Human",
     description: "Created with heart, intent, and sometimes AI — but always by a human. A positive movement celebrating human creativity and the meaningful choices we make in our creative work.",
-    images: [`${basePath}/og-image.png`],
+    images: [`/og-image.png`],
     creator: "@iamjarl",
   },
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -526,7 +526,7 @@ export default function Home() {
                 Copy the markdown code and paste it directly into your README.md file to display your badge.
               </p>
               <div className="bg-zinc-900 dark:bg-zinc-800 rounded-lg p-4 text-sm font-mono text-zinc-100">
-                <code>{'![Co-created with AI](https://jarllyng.github.io/madebyhuman/badges/co-created-white.svg)'}</code>
+                <code>{`![Co-created with AI](${getFullBadgeUrl('co-created', 'white')})`}</code>
               </div>
             </div>
 
@@ -536,7 +536,7 @@ export default function Home() {
                 Copy the HTML code and paste it into your website to display your badge.
               </p>
               <div className="bg-zinc-900 dark:bg-zinc-800 rounded-lg p-4 text-sm font-mono text-zinc-100">
-                <code>{'<img src="https://jarllyng.github.io/madebyhuman/badges/co-created-white.svg" alt="Co-created with AI" width="360" height="120">'}</code>
+                <code>{`<img src="${getFullBadgeUrl('co-created', 'white')}" alt="Co-created with AI" width="360" height="120">`}</code>
               </div>
             </div>
 


### PR DESCRIPTION
Update project to use custom domain madebyhuman.iamjarl.com

Changes:
- Remove basePath configuration (no longer needed with custom domain)
- Update all URLs from jarllyng.github.io/madebyhuman to madebyhuman.iamjarl.com
- Update config.ts to use new domain and remove basePath logic
- Update next.config.ts to remove basePath
- Update layout.tsx metadata to use new domain
- Update README.md with new URLs
- Update sitemap.xml and robots.txt
- Update GitHub Actions workflow to set NEXT_PUBLIC_SITE_ORIGIN
- Update example embed codes in page.tsx to use dynamic URLs