### PR TITLE
chore: improve dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
         dependency-type: "production"
       development-dependencies:
         dependency-type: "development"
+    # Versioning strategy: increase for patch/minor, create separate PRs for major
+    versioning-strategy: increase
     # Ignore major version updates for @types/node to avoid breaking changes
     ignore:
       - dependency-name: "@types/node"
@@ -35,4 +37,5 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    versioning-strategy: increase
 


### PR DESCRIPTION
Add versioning-strategy to Dependabot config for better version control

- Add versioning-strategy: increase for npm packages
- Add versioning-strategy: increase for GitHub Actions
- This ensures Dependabot updates to the highest version within semver range

Made with [Cursor](https://cursor.com)