### PR TITLE
feat: SEO strategy, /about and /badges pages

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "/Users/jarl.l/.nvm/versions/node/v24.5.0/bin/node",
+      "runtimeArgs": ["-e", "const http=require('http'),fs=require('fs'),path=require('path');const dir='/Users/jarl.l/Downloads/github/madebyhuman/out';const mime={'.html':'text/html','.js':'application/javascript','.css':'text/css','.svg':'image/svg+xml','.png':'image/png','.ico':'image/x-icon','.json':'application/json'};http.createServer((req,res)=>{let p=req.url.split('?')[0];if(p.endsWith('/'))p+='index.html';if(!path.extname(p))p+='.html';const fp=path.join(dir,p);fs.readFile(fp,(err,data)=>{if(err){res.writeHead(404);res.end('Not found');return;}res.writeHead(200,{'Content-Type':mime[path.extname(fp)]||'application/octet-stream'});res.end(data);});}).listen(3000)"],
+      "port": 3000
+    }
+  ]
+}

--- a/SEO_STRATEGY.md
+++ b/SEO_STRATEGY.md
@@ -1,0 +1,184 @@
+# SEO Strategy — Made by Human
+
+**Site:** https://madebyhuman.iamjarl.com
+**Google Search Console:** Connected
+**Analytics:** Umami
+**Last updated:** 2026-03-22
+
+---
+
+## 1. Current Status
+
+### What's in place
+- Meta title, description, and keywords in `layout.tsx`
+- Open Graph and Twitter Card metadata with `og-image.png`
+- Canonical URL configured
+- `robots.txt` allowing full crawl + sitemap reference
+- Static `sitemap.xml` with one entry
+- Google Search Console verification (`google25b9a18021b6d68d.html`)
+- Umami analytics tracking with custom events (badge clicks, downloads, copies)
+
+### What's missing
+- JSON-LD structured data
+- Dynamic sitemap generation (currently static, manually maintained)
+- Content strategy (blog/articles)
+- Backlink strategy
+- Performance monitoring via Search Console (newly added)
+- Multi-language support (potential Danish/Scandinavian audience)
+
+---
+
+## 2. Target Audience & Keywords
+
+### Primary audience
+- Developers and designers who want to signal human involvement in their work
+- Open source contributors looking for badges for their projects
+- Creatives exploring the intersection of AI and human creativity
+
+### Primary keywords
+| Keyword | Intent | Priority |
+|---------|--------|----------|
+| made by human badge | Transactional | High |
+| human made badge for github | Transactional | High |
+| co-created with ai badge | Transactional | High |
+| crafted by human badge | Transactional | Medium |
+| human in the loop badge | Transactional | Medium |
+| human creativity badge | Informational | Medium |
+| ai collaboration badge | Transactional | Medium |
+
+### Long-tail keywords
+- "how to add a made by human badge to github readme"
+- "free badges for open source projects"
+- "human vs ai created content badge"
+- "show human involvement in project"
+- "human creativity in the age of ai"
+
+---
+
+## 3. Technical SEO
+
+### 3.1 Structured Data (JSON-LD)
+Add the following schemas to `layout.tsx`:
+
+- **WebSite** — helps Google understand the site identity
+- **Organization** — establishes brand presence
+- **BreadcrumbList** — if additional pages are added
+
+### 3.2 Sitemap
+- Automate sitemap generation or update `lastmod` on each deploy
+- Add new pages to sitemap as content grows
+
+### 3.3 Performance
+- Site is statically exported (Next.js `output: 'export'`) — excellent for Core Web Vitals
+- SVG badges are lightweight
+- Monitor Core Web Vitals in Search Console
+
+### 3.4 Indexing
+- [x] Submit sitemap in Google Search Console
+- [ ] Request indexing of main page
+- [ ] Monitor "Coverage" report for crawl issues
+- [ ] Add Bing Webmaster Tools
+
+---
+
+## 4. Content Strategy
+
+### 4.1 Additional Pages (Phase 1)
+Consider adding these pages to increase keyword coverage:
+
+| Page | Purpose | Target Keywords |
+|------|---------|----------------|
+| `/about` | Deeper story about the movement | human creativity movement, made by human mission |
+| `/badges` | Dedicated badge gallery with full descriptions | free open source badges, github readme badges |
+| `/guide` | How to choose and use the right badge | how to add badge to github, badge embed guide |
+
+### 4.2 Blog/Articles (Phase 2)
+A `/blog` section could capture informational search traffic:
+
+- "Why Transparency About AI Use Matters"
+- "How to Signal Human Creativity in Your Projects"
+- "The Difference Between AI-Generated and Human-Curated Work"
+- "Adding Badges to Your GitHub README: A Complete Guide"
+
+### 4.3 Content Principles
+- Write for humans first, search engines second
+- Focus on the positive framing (celebrating human creativity, not anti-AI)
+- Keep content concise and actionable
+
+---
+
+## 5. Link Building & Distribution
+
+### 5.1 GitHub Presence
+- Optimize the GitHub repo README with badge examples and clear descriptions
+- Encourage users to link back to the site when using badges
+- Add the site URL to the GitHub repo "About" section
+
+### 5.2 Community & Outreach
+- Share on relevant developer communities (Hacker News, Reddit r/opensource, Dev.to)
+- Submit to badge directories and "awesome" lists on GitHub
+- Reach out to bloggers writing about AI and human creativity
+
+### 5.3 Badge-Driven Backlinks
+Each badge embeds a URL back to the site. As adoption grows, this creates organic backlinks:
+- Markdown embeds in READMEs link to the badge image hosted on the domain
+- Consider adding an optional link wrapper so badges can link back to the site
+
+---
+
+## 6. Monitoring & KPIs
+
+### Search Console Metrics
+| Metric | Baseline | Target (3 months) | Target (6 months) |
+|--------|----------|--------------------|--------------------|
+| Indexed pages | 1 | 4+ | 8+ |
+| Total impressions | TBD | 500/month | 2,000/month |
+| Total clicks | TBD | 50/month | 300/month |
+| Average position | TBD | Top 20 for primary keywords | Top 10 for primary keywords |
+
+### Umami Metrics
+| Metric | What it tells us |
+|--------|-----------------|
+| Badge download events | Which badges are most popular |
+| Copy embed events | Adoption signal — people embedding badges |
+| GitHub repo click events | Interest in contributing |
+| Page views & unique visitors | Overall reach |
+
+### Review Cadence
+- **Weekly:** Check Search Console for crawl errors and new queries
+- **Monthly:** Review impressions, clicks, and keyword rankings
+- **Quarterly:** Evaluate content strategy and adjust keyword targets
+
+---
+
+## 7. Implementation Roadmap
+
+### Phase 1 — Foundation (Now)
+- [x] Google Search Console connected
+- [x] Add JSON-LD structured data (WebSite + Organization) — added to `layout.tsx`
+- [x] Update `sitemap.xml` lastmod to auto-update on deploy — `scripts/generate-sitemap.mjs` runs as `prebuild`
+- [ ] Request indexing in Search Console
+- [ ] Add Bing Webmaster Tools
+- [ ] Set baseline metrics
+
+### Phase 2 — Content Expansion (1-2 months)
+- [ ] Create `/about` page
+- [ ] Create dedicated `/badges` page with richer descriptions
+- [ ] Create `/guide` page with step-by-step instructions
+- [ ] Update sitemap with new pages
+- [ ] Optimize internal linking between pages
+
+### Phase 3 — Growth (3-6 months)
+- [ ] Launch blog with first 2-3 articles
+- [ ] Begin outreach to developer communities
+- [ ] Submit to "awesome" lists and badge directories
+- [ ] Consider `hreflang` tags if targeting Scandinavian audience
+- [ ] Evaluate adding a badge link-back feature for organic backlinks
+
+---
+
+## 8. Notes
+
+- The site uses static export, so any dynamic features (dynamic sitemap, server-side rendering) would require a change in hosting strategy or build-time generation.
+- The current single-page structure is effective for a focused project but limits keyword coverage. Adding even 2-3 pages significantly improves SEO potential.
+- Badge adoption is the strongest organic growth lever — every README that embeds a badge is a potential backlink and brand impression.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/generate-sitemap.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,9 +2,20 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://madebyhuman.iamjarl.com/</loc>
-    <lastmod>2025-12-26</lastmod>
+    <lastmod>2026-03-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://madebyhuman.iamjarl.com/about</loc>
+    <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://madebyhuman.iamjarl.com/badges</loc>
+    <lastmod>2026-03-22</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
 </urlset>
-

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,0 +1,33 @@
+import { writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_ORIGIN || 'https://madebyhuman.iamjarl.com';
+const today = new Date().toISOString().split('T')[0];
+
+// Add new pages here as the site grows
+const pages = [
+  { path: '/', changefreq: 'weekly', priority: '1.0' },
+  { path: '/about', changefreq: 'monthly', priority: '0.8' },
+  { path: '/badges', changefreq: 'weekly', priority: '0.9' },
+];
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${pages
+  .map(
+    (page) => `  <url>
+    <loc>${SITE_URL}${page.path}</loc>
+    <lastmod>${today}</lastmod>
+    <changefreq>${page.changefreq}</changefreq>
+    <priority>${page.priority}</priority>
+  </url>`
+  )
+  .join('\n')}
+</urlset>
+`;
+
+const outputPath = resolve(__dirname, '../public/sitemap.xml');
+writeFileSync(outputPath, sitemap, 'utf-8');
+console.log(`Sitemap generated: ${outputPath} (lastmod: ${today})`);

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,161 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { getBaseUrl } from '../config';
+
+const baseUrl = getBaseUrl();
+
+export const metadata: Metadata = {
+  title: 'About - Made by Human',
+  description:
+    'The story behind Made by Human — a positive movement celebrating human creativity, intention, and the meaningful choices we make when we create.',
+  alternates: {
+    canonical: `${baseUrl}/about`,
+  },
+  openGraph: {
+    title: 'About - Made by Human',
+    description:
+      'The story behind Made by Human — a positive movement celebrating human creativity, intention, and the meaningful choices we make when we create.',
+    url: `${baseUrl}/about`,
+  },
+};
+
+export default function AboutPage() {
+  return (
+    <main className="min-h-screen bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-50">
+      {/* Header */}
+      <section className="px-4 sm:px-6 lg:px-8 py-24 sm:py-32">
+        <div className="max-w-4xl mx-auto text-center">
+          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight mb-6">
+            About Made by Human
+          </h1>
+          <p className="text-xl sm:text-2xl text-zinc-600 dark:text-zinc-400 font-light max-w-2xl mx-auto">
+            Why define something by what it&apos;s not?
+            Why &ldquo;Not By AI&rdquo; and not &ldquo;Made by Human&rdquo;?
+          </p>
+        </div>
+      </section>
+
+      {/* Origin Story */}
+      <section className="px-4 sm:px-6 lg:px-8 py-16 sm:py-20 bg-zinc-50 dark:bg-zinc-900">
+        <div className="max-w-6xl mx-auto">
+          <div className="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-8 lg:gap-16 items-start">
+            <h2 className="text-3xl sm:text-4xl font-bold lg:text-right">
+              The Origin
+            </h2>
+            <div className="space-y-6 text-lg text-zinc-700 dark:text-zinc-300 pt-2">
+              <p>
+                It started with a simple observation. Initiatives like &ldquo;Not By AI&rdquo;
+                label content as human-made — a kind of Fairtrade label for text and creativity.
+                The intention is genuine: transparency about how something was made.
+              </p>
+              <p>
+                But there&apos;s an unspoken message in defining things by what they&apos;re <em>not</em>.
+                When we start labelling what&apos;s not made by AI, are we also saying that everything
+                else is worth less? Or that human-made automatically means better?
+              </p>
+              <p>
+                <strong>Made by Human</strong> is a friendly counterpoint. Not a protest.
+                More a reminder that there&apos;s still a human behind it all — even when AI is part
+                of the process.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Philosophy */}
+      <section className="px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
+        <div className="max-w-6xl mx-auto">
+          <div className="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-8 lg:gap-16 items-start">
+            <h2 className="text-3xl sm:text-4xl font-bold lg:text-right">
+              Intention Over Purity
+            </h2>
+            <div className="space-y-6 text-lg text-zinc-700 dark:text-zinc-300 pt-2">
+              <p>
+                It&apos;s not about how something is made — it&apos;s about <em>why</em>.
+              </p>
+              <p>
+                Music can feel more genuine when you know the story behind it. A small mistake,
+                a pause, an imperfection can make it feel more human. The same goes for design,
+                code, and communication. Authenticity doesn&apos;t live in the tool — it lives
+                in the intention, and in the connection we create.
+              </p>
+              <p>
+                Sometimes the process starts with an AI tool that sparks an idea. Other times,
+                it&apos;s intuition, experience, and human sensibility that lead the way. Most
+                often, it&apos;s the combination that works best.
+              </p>
+              <p>
+                True value emerges when humans <strong>choose</strong>, <strong>shape</strong>,
+                and <strong>curate</strong> their tools. Whether working entirely by hand or in
+                collaboration with AI, the creative vision and decisions remain fundamentally human.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* The Badges */}
+      <section className="px-4 sm:px-6 lg:px-8 py-16 sm:py-20 bg-zinc-50 dark:bg-zinc-900">
+        <div className="max-w-6xl mx-auto">
+          <div className="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-8 lg:gap-16 items-start">
+            <h2 className="text-3xl sm:text-4xl font-bold lg:text-right">
+              The Badges
+            </h2>
+            <div className="space-y-6 text-lg text-zinc-700 dark:text-zinc-300 pt-2">
+              <p>
+                Our badges represent different nuances in how humans and machines work together.
+                They&apos;re free to use on websites, products, music, apps, and art projects — each
+                one acknowledging a different relationship between human and tool.
+              </p>
+              <p>
+                They&apos;re not labels of quality or gatekeeping. They&apos;re small, honest signals
+                about the process behind the work.
+              </p>
+              <p className="pt-2">
+                <Link
+                  href="/badges"
+                  className="text-zinc-900 dark:text-zinc-100 underline hover:text-zinc-600 dark:hover:text-zinc-400 font-medium"
+                >
+                  Explore and download all badges
+                </Link>
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Future Vision */}
+      <section className="px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
+        <div className="max-w-6xl mx-auto">
+          <div className="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-8 lg:gap-16 items-start">
+            <h2 className="text-3xl sm:text-4xl font-bold lg:text-right">
+              Looking Forward
+            </h2>
+            <div className="space-y-6 text-lg text-zinc-700 dark:text-zinc-300 pt-2">
+              <p>
+                Maybe the labels of the future shouldn&apos;t be about what&apos;s <em>not</em> made
+                by AI. Maybe they should remind us <em>why</em> we create things in the first place.
+              </p>
+              <p>
+                Made by Human is open source. Everyone is welcome to contribute — bring your badges,
+                ideas, text, design, or code. Our goal is to celebrate the human in every creative
+                process, whether that process includes AI or not.
+              </p>
+              <p className="pt-2">
+                <a
+                  href="https://github.com/JarlLyng/madebyhuman"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-zinc-900 dark:text-zinc-100 underline hover:text-zinc-600 dark:hover:text-zinc-400 font-medium"
+                >
+                  Contribute on GitHub
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/badges/layout.tsx
+++ b/src/app/badges/layout.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next';
+import { getBaseUrl } from '../config';
+
+const baseUrl = getBaseUrl();
+
+export const metadata: Metadata = {
+  title: 'Badges - Made by Human',
+  description:
+    'Free badges for your projects — Made by Human, Co-created with AI, Crafted by Human, and Human in the Loop. Download SVGs or copy embed codes for your README, website, or portfolio.',
+  alternates: {
+    canonical: `${baseUrl}/badges`,
+  },
+  openGraph: {
+    title: 'Badges - Made by Human',
+    description:
+      'Free badges for your projects — signal human creativity and transparency about AI collaboration.',
+    url: `${baseUrl}/badges`,
+  },
+};
+
+export default function BadgesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/badges/page.tsx
+++ b/src/app/badges/page.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import { badges } from '@/lib/badges';
+import type { Badge } from '@/lib/badges';
+import { getBadgeUrl, getFullBadgeUrl } from '../config';
+import { trackEvent } from '@/lib/umami';
+
+function BadgeSection({ badge }: { badge: Badge }) {
+  const [variant, setVariant] = useState<'white' | 'black'>('white');
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const fullUrl = getFullBadgeUrl(badge.filename, variant);
+
+  const embedCodes = {
+    markdown: `![${badge.name}](${fullUrl})`,
+    html: `<img src="${fullUrl}" alt="${badge.name}" width="360" height="120">`,
+    url: fullUrl,
+  };
+
+  const copyCode = async (type: 'markdown' | 'html' | 'url') => {
+    try {
+      await navigator.clipboard.writeText(embedCodes[type]);
+      setCopied(type);
+      setTimeout(() => setCopied(null), 2000);
+      trackEvent('copy_embed', { badge: badge.filename, variant, type });
+    } catch {
+      // Silently fail
+    }
+  };
+
+  const downloadBadge = () => {
+    try {
+      const url = getBadgeUrl(badge.filename, variant);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${badge.filename}-${variant}.svg`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      trackEvent('download_badge', { badge: badge.filename, variant });
+    } catch {
+      window.open(getBadgeUrl(badge.filename, variant), '_blank');
+    }
+  };
+
+  return (
+    <section className="px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
+      <div className="max-w-6xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12 items-start">
+          {/* Badge Preview */}
+          <div>
+            <div
+              className="rounded-lg p-8 flex items-center justify-center mb-4"
+              style={{ backgroundColor: '#F59898' }}
+            >
+              <Image
+                src={getBadgeUrl(badge.filename, variant)}
+                alt={badge.name}
+                width={360}
+                height={120}
+                className="w-full max-w-sm h-auto"
+              />
+            </div>
+            <div className="flex gap-3 mb-4">
+              <button
+                onClick={() => setVariant('white')}
+                className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
+                  variant === 'white'
+                    ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
+                    : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100'
+                }`}
+              >
+                White
+              </button>
+              <button
+                onClick={() => setVariant('black')}
+                className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
+                  variant === 'black'
+                    ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
+                    : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100'
+                }`}
+              >
+                Black
+              </button>
+            </div>
+            <button
+              onClick={downloadBadge}
+              className="w-full px-6 py-3 bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 rounded-lg hover:bg-zinc-800 dark:hover:bg-zinc-200 transition-colors font-medium"
+            >
+              Download SVG
+            </button>
+          </div>
+
+          {/* Badge Info */}
+          <div>
+            <h2 className="text-2xl sm:text-3xl font-bold mb-3">{badge.name}</h2>
+            <p className="text-lg text-zinc-700 dark:text-zinc-300 mb-6">
+              {badge.longDescription}
+            </p>
+
+            <h3 className="font-semibold text-sm uppercase tracking-wide text-zinc-500 dark:text-zinc-400 mb-3">
+              When to use
+            </h3>
+            <ul className="space-y-2 mb-8">
+              {badge.useCases.map((useCase) => (
+                <li
+                  key={useCase}
+                  className="text-zinc-600 dark:text-zinc-400 flex items-start gap-2"
+                >
+                  <span className="text-zinc-400 dark:text-zinc-600 mt-1 shrink-0">&mdash;</span>
+                  {useCase}
+                </li>
+              ))}
+            </ul>
+
+            <h3 className="font-semibold text-sm uppercase tracking-wide text-zinc-500 dark:text-zinc-400 mb-3">
+              Embed code
+            </h3>
+            <div className="space-y-2">
+              <button
+                onClick={() => copyCode('markdown')}
+                className="w-full text-left px-4 py-2 bg-zinc-50 dark:bg-zinc-800 rounded border border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-700 transition-colors text-sm"
+              >
+                {copied === 'markdown' ? '✓ Copied!' : 'Copy Markdown'}
+              </button>
+              <button
+                onClick={() => copyCode('html')}
+                className="w-full text-left px-4 py-2 bg-zinc-50 dark:bg-zinc-800 rounded border border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-700 transition-colors text-sm"
+              >
+                {copied === 'html' ? '✓ Copied!' : 'Copy HTML'}
+              </button>
+              <button
+                onClick={() => copyCode('url')}
+                className="w-full text-left px-4 py-2 bg-zinc-50 dark:bg-zinc-800 rounded border border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-700 transition-colors text-sm"
+              >
+                {copied === 'url' ? '✓ Copied!' : 'Copy Image URL'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function BadgesPage() {
+  return (
+    <main className="min-h-screen bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-50">
+      {/* Header */}
+      <section className="px-4 sm:px-6 lg:px-8 py-24 sm:py-32">
+        <div className="max-w-4xl mx-auto text-center">
+          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight mb-6">
+            Badge Gallery
+          </h1>
+          <p className="text-xl sm:text-2xl text-zinc-600 dark:text-zinc-400 font-light max-w-2xl mx-auto">
+            Free badges for your projects. Each one signals a different relationship between human creativity and technology.
+          </p>
+        </div>
+      </section>
+
+      {/* Badge Sections */}
+      {badges.map((badge, index) => (
+        <div
+          key={badge.filename}
+          className={index % 2 === 0 ? 'bg-zinc-50 dark:bg-zinc-900' : ''}
+        >
+          <BadgeSection badge={badge} />
+        </div>
+      ))}
+
+      {/* CTA */}
+      <section className="px-4 sm:px-6 lg:px-8 py-16 sm:py-20 text-center">
+        <div className="max-w-2xl mx-auto">
+          <h2 className="text-2xl sm:text-3xl font-bold mb-4">
+            Have an idea for a new badge?
+          </h2>
+          <p className="text-lg text-zinc-600 dark:text-zinc-400 mb-6">
+            Made by Human is open source. Contribute your own badge designs, ideas, or improvements.
+          </p>
+          <a
+            href="https://github.com/JarlLyng/madebyhuman"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block px-8 py-3 bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 rounded-lg hover:bg-zinc-800 dark:hover:bg-zinc-200 transition-colors font-medium"
+          >
+            Contribute on GitHub
+          </a>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Script from "next/script";
 import { getBaseUrl } from "./config";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -75,6 +77,40 @@ export const metadata: Metadata = {
   },
 };
 
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebSite',
+      '@id': `${baseUrl}/#website`,
+      url: `${baseUrl}/`,
+      name: 'Made by Human',
+      description: 'A positive movement celebrating human creativity and the meaningful choices we make in our creative work.',
+      publisher: { '@id': `${baseUrl}/#organization` },
+    },
+    {
+      '@type': 'Organization',
+      '@id': `${baseUrl}/#organization`,
+      name: 'Made by Human',
+      url: `${baseUrl}/`,
+      logo: {
+        '@type': 'ImageObject',
+        url: `${baseUrl}/og-image.png`,
+        width: 1200,
+        height: 630,
+      },
+      founder: {
+        '@type': 'Person',
+        name: 'IAMJARL',
+        url: 'https://iamjarl.com',
+      },
+      sameAs: [
+        'https://github.com/JarlLyng/madebyhuman',
+      ],
+    },
+  ],
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -82,6 +118,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
@@ -90,7 +132,9 @@ export default function RootLayout({
           data-website-id="a8ee647d-8843-48d5-8cbc-33224e12ad61"
           strategy="afterInteractive"
         />
+        <Nav />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,57 +5,15 @@ import Image from 'next/image';
 import { motion, useMotionValue, useSpring, useMotionTemplate } from 'framer-motion';
 import { getBadgeUrl, getFullBadgeUrl } from './config';
 
-declare global {
-  interface Window {
-    umami?: {
-      track: (eventName: string, data?: Record<string, unknown>) => void;
-    };
-  }
-}
-
-interface Badge {
-  name: string;
-  filename: string;
-  description: string;
-}
-
-const badges: Badge[] = [
-  {
-    name: 'Made by Human',
-    filename: 'made',
-    description: 'A general badge celebrating human creativity in all forms',
-  },
-  {
-    name: 'Co-created with AI',
-    filename: 'co-created',
-    description: 'For projects created in collaboration with AI tools',
-  },
-  {
-    name: 'Crafted by Human',
-    filename: 'crafted',
-    description: 'For projects created entirely by human hands',
-  },
-  {
-    name: 'Human in the Loop',
-    filename: 'loop',
-    description: 'For projects where humans guide and curate the creative process',
-  },
-];
+import { badges } from '@/lib/badges';
+import type { Badge } from '@/lib/badges';
+import { trackEvent } from '@/lib/umami';
 
 export default function Home() {
   const [selectedBadge, setSelectedBadge] = useState<Badge | null>(null);
   const [selectedVariant, setSelectedVariant] = useState<'white' | 'black'>('white');
   const [copied, setCopied] = useState<string | null>(null);
   const [isTouchDevice, setIsTouchDevice] = useState(false);
-
-  const trackEvent = (eventName: string, data?: Record<string, unknown>) => {
-    if (typeof window === 'undefined') return;
-    try {
-      window.umami?.track(eventName, data);
-    } catch {
-      // Ignore tracking errors to avoid breaking UX
-    }
-  };
 
   // Smooth spring animation for mouse position
   const mouseX = useSpring(useMotionValue(0), { stiffness: 50, damping: 20 });
@@ -600,46 +558,6 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="px-4 sm:px-6 lg:px-8 py-12 border-t border-zinc-200 dark:border-zinc-800">
-        <div className="max-w-6xl mx-auto text-center space-y-6">
-          <div className="flex justify-center">
-            <Image
-              src={getBadgeUrlForBadge(badges[0], 'white')}
-              alt="Co-created with AI"
-              width={360}
-              height={120}
-              className="h-16 w-auto dark:hidden"
-            />
-            <Image
-              src={getBadgeUrlForBadge(badges[0], 'black')}
-              alt="Co-created with AI"
-              width={360}
-              height={120}
-              className="h-16 w-auto hidden dark:block"
-            />
-          </div>
-          <div className="text-sm text-zinc-600 dark:text-zinc-400 space-y-2">
-            <p>
-              This project is open source under the MIT License.
-            </p>
-            <p>
-              Share, remix, and build upon it — and remember to credit the humans who made it.
-            </p>
-            <p className="mt-4">
-              Made by{' '}
-              <a
-                href="https://iamjarl.com/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-zinc-900 dark:text-zinc-100 underline hover:text-zinc-600 dark:hover:text-zinc-400 font-medium"
-              >
-                IAMJARL
-              </a>
-            </p>
-          </div>
-        </div>
-      </footer>
     </main>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,42 @@
+import Image from 'next/image';
+import { getBadgeUrl } from '@/app/config';
+
+export default function Footer() {
+  return (
+    <footer className="px-4 sm:px-6 lg:px-8 py-12 border-t border-zinc-200 dark:border-zinc-800">
+      <div className="max-w-6xl mx-auto text-center space-y-6">
+        <div className="flex justify-center">
+          <Image
+            src={getBadgeUrl('made', 'white')}
+            alt="Made by Human"
+            width={360}
+            height={120}
+            className="h-16 w-auto dark:hidden"
+          />
+          <Image
+            src={getBadgeUrl('made', 'black')}
+            alt="Made by Human"
+            width={360}
+            height={120}
+            className="h-16 w-auto hidden dark:block"
+          />
+        </div>
+        <div className="text-sm text-zinc-600 dark:text-zinc-400 space-y-2">
+          <p>This project is open source under the MIT License.</p>
+          <p>Share, remix, and build upon it — and remember to credit the humans who made it.</p>
+          <p className="mt-4">
+            Made by{' '}
+            <a
+              href="https://iamjarl.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-zinc-900 dark:text-zinc-100 underline hover:text-zinc-600 dark:hover:text-zinc-400 font-medium"
+            >
+              IAMJARL
+            </a>
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+
+export default function Nav() {
+  return (
+    <nav className="px-4 sm:px-6 lg:px-8 py-4">
+      <div className="max-w-6xl mx-auto flex items-center justify-between">
+        <Link
+          href="/"
+          className="font-bold text-lg text-zinc-900 dark:text-zinc-50 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+        >
+          Made by Human
+        </Link>
+        <div className="flex items-center gap-6 text-sm font-medium">
+          <Link
+            href="/about"
+            className="text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+          >
+            About
+          </Link>
+          <Link
+            href="/badges"
+            className="text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+          >
+            Badges
+          </Link>
+          <a
+            href="https://github.com/JarlLyng/madebyhuman"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+          >
+            GitHub
+          </a>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/lib/badges.ts
+++ b/src/lib/badges.ts
@@ -1,0 +1,58 @@
+export interface Badge {
+  name: string;
+  filename: string;
+  description: string;
+  longDescription: string;
+  useCases: string[];
+}
+
+export const badges: Badge[] = [
+  {
+    name: 'Made by Human',
+    filename: 'made',
+    description: 'A general badge celebrating human creativity in all forms',
+    longDescription:
+      'The original badge. A simple, positive statement that a human was behind this work — making the choices, shaping the vision, and taking ownership of the final result. It doesn\'t say anything about how the work was made. It says something about who made it.',
+    useCases: [
+      'Any project where you want to acknowledge the human behind it',
+      'Websites, portfolios, and personal projects',
+      'Open source repositories',
+    ],
+  },
+  {
+    name: 'Co-created with AI',
+    filename: 'co-created',
+    description: 'For projects created in collaboration with AI tools',
+    longDescription:
+      'For the honest middle ground. This badge says: yes, AI was part of the process — and a human guided it. It\'s not about purity, it\'s about transparency. The human chose, shaped, and curated. The machine helped.',
+    useCases: [
+      'Projects where AI tools helped generate, refine, or translate content',
+      'Code written with AI assistance',
+      'Designs that started with AI-generated concepts and were refined by hand',
+    ],
+  },
+  {
+    name: 'Crafted by Human',
+    filename: 'crafted',
+    description: 'For projects created entirely by human hands',
+    longDescription:
+      'For work made without AI in the process. Not as a statement against technology, but as a quiet nod to the craft — the analog, the handmade, the entirely human. Sometimes a mistake, a pause, or an imperfection is what makes it feel real.',
+    useCases: [
+      'Hand-coded projects without AI code generation',
+      'Handwritten articles, essays, and poetry',
+      'Music, art, and design made entirely by human hands',
+    ],
+  },
+  {
+    name: 'Human in the Loop',
+    filename: 'loop',
+    description: 'For projects where humans guide and curate the creative process',
+    longDescription:
+      'For workflows where AI plays a significant role, but a human is always there — reviewing, deciding, adjusting. The human doesn\'t just press a button. They stay in the loop, making the choices that matter.',
+    useCases: [
+      'AI-heavy workflows with human oversight and editorial control',
+      'Automated pipelines with human quality gates',
+      'Content pipelines where humans curate and approve AI output',
+    ],
+  },
+];

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -1,0 +1,16 @@
+declare global {
+  interface Window {
+    umami?: {
+      track: (eventName: string, data?: Record<string, unknown>) => void;
+    };
+  }
+}
+
+export function trackEvent(eventName: string, data?: Record<string, unknown>) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.umami?.track(eventName, data);
+  } catch {
+    // Ignore tracking errors to avoid breaking UX
+  }
+}


### PR DESCRIPTION
## Summary
- **SEO Strategy document** (`SEO_STRATEGY.md`) with keyword targets, content plan, and implementation roadmap
- **JSON-LD structured data** (WebSite + Organization schema) in layout for rich search results
- **Auto-generated sitemap** via `prebuild` script — `lastmod` updates on every deploy
- **`/about` page** — origin story, philosophy, and vision behind the movement
- **`/badges` page** — dedicated gallery with rich descriptions, use cases, variant switcher, download, and embed codes
- **Shared components** — extracted Nav, Footer, badge data, and Umami tracking into reusable modules

## SEO Impact
- 3 indexable pages (up from 1)
- Dedicated meta titles, descriptions, canonical URLs, and Open Graph per page
- Structured data for Google rich results
- Keyword-targeted content for "made by human badge", "co-created with ai badge", etc.

## Test plan
- [ ] Verify all three pages render correctly (`/`, `/about`, `/badges`)
- [ ] Verify navigation links work between pages
- [ ] Verify badge download and embed copy buttons work on `/badges`
- [ ] Verify `npm run build` succeeds with all 3 static pages
- [ ] Verify sitemap includes all pages with current date
- [ ] Verify JSON-LD is present in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new indexable routes and changes the build pipeline via a `prebuild` sitemap generator, which could impact deploy/build behavior if the script or env origin is misconfigured. Otherwise changes are mostly content/UI and metadata, with minimal security or data-handling risk.
> 
> **Overview**
> Adds new SEO-focused site structure by introducing `/about` and a dedicated `/badges` gallery page (download + copy-embed actions), plus shared `Nav`/`Footer` components wired into `RootLayout`.
> 
> Improves search metadata by injecting JSON-LD (`WebSite` + `Organization`) in `layout.tsx`, adding per-route canonical/OpenGraph metadata, and centralizing badge definitions and Umami tracking into `src/lib/*`.
> 
> Automates `public/sitemap.xml` generation/`lastmod` updates via `scripts/generate-sitemap.mjs` run on `npm run prebuild`, and documents the SEO plan in `SEO_STRATEGY.md` (also adds a local `.claude/launch.json` dev helper).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d23ef971ebf4bd2ad1c41894bf03297220aac357. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->