### PR TITLE
feat: accessibility improvements (WCAG AA) and Medium article link

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -81,6 +81,17 @@ export default function AboutPage() {
                 More a reminder that there&apos;s still a human behind it all — even when AI is part
                 of the process.
               </p>
+              <p className="pt-2">
+                <a
+                  href="https://medium.com/@jarllyng/made-by-human-6fe8ccf0ce2f"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-zinc-900 dark:text-zinc-100 underline hover:text-zinc-600 dark:hover:text-zinc-400 font-medium"
+                >
+                  Read the full story on Medium
+                </a>
+                <span className="sr-only"> (opens in a new tab)</span>
+              </p>
             </div>
           </div>
         </div>

--- a/src/app/badges/page.tsx
+++ b/src/app/badges/page.tsx
@@ -60,9 +60,14 @@ function BadgeSection({ badge }: { badge: Badge }) {
                 className="w-full max-w-sm h-auto"
               />
             </div>
-            <div className="flex gap-3 mb-4">
+            <div
+              className="flex gap-3 mb-4"
+              role="group"
+              aria-label={`${badge.name} variant`}
+            >
               <button
                 onClick={() => setVariant('white')}
+                aria-pressed={variant === 'white'}
                 className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
                   variant === 'white'
                     ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
@@ -73,6 +78,7 @@ function BadgeSection({ badge }: { badge: Badge }) {
               </button>
               <button
                 onClick={() => setVariant('black')}
+                aria-pressed={variant === 'black'}
                 className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
                   variant === 'black'
                     ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
@@ -84,6 +90,7 @@ function BadgeSection({ badge }: { badge: Badge }) {
             </div>
             <button
               onClick={downloadBadge}
+              aria-label={`Download ${badge.name} ${variant} variant as SVG`}
               className="w-full px-6 py-3 bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 rounded-lg hover:bg-zinc-800 dark:hover:bg-zinc-200 transition-colors font-medium"
             >
               Download SVG
@@ -118,22 +125,29 @@ function BadgeSection({ badge }: { badge: Badge }) {
             <div className="space-y-2">
               <button
                 onClick={() => copyCode('markdown')}
+                aria-label={`Copy ${badge.name} markdown embed code`}
                 className="w-full text-left px-4 py-2 bg-zinc-50 dark:bg-zinc-800 rounded border border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-700 transition-colors text-sm"
               >
                 {copied === 'markdown' ? '✓ Copied!' : 'Copy Markdown'}
               </button>
               <button
                 onClick={() => copyCode('html')}
+                aria-label={`Copy ${badge.name} HTML embed code`}
                 className="w-full text-left px-4 py-2 bg-zinc-50 dark:bg-zinc-800 rounded border border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-700 transition-colors text-sm"
               >
                 {copied === 'html' ? '✓ Copied!' : 'Copy HTML'}
               </button>
               <button
                 onClick={() => copyCode('url')}
+                aria-label={`Copy ${badge.name} image URL`}
                 className="w-full text-left px-4 py-2 bg-zinc-50 dark:bg-zinc-800 rounded border border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-700 transition-colors text-sm"
               >
                 {copied === 'url' ? '✓ Copied!' : 'Copy Image URL'}
               </button>
+            </div>
+            {/* Screen reader announcement for copy action */}
+            <div className="sr-only" role="status" aria-live="polite">
+              {copied ? `${copied} embed code copied to clipboard` : ''}
             </div>
           </div>
         </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -35,3 +35,47 @@ body {
   color: var(--foreground);
   font-family: var(--font-geist-sans), -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
+
+/* Accessible focus styles for keyboard users */
+*:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+@media (prefers-color-scheme: dark) {
+  *:focus-visible {
+    outline-color: #60a5fa;
+  }
+}
+
+/* Skip-to-content link — visible only when focused */
+.skip-to-content {
+  position: absolute;
+  left: 1rem;
+  top: 1rem;
+  z-index: 100;
+  padding: 0.5rem 1rem;
+  background: var(--foreground);
+  color: var(--background);
+  border-radius: 0.375rem;
+  font-weight: 500;
+  transform: translateY(-150%);
+  transition: transform 0.2s;
+}
+
+.skip-to-content:focus {
+  transform: translateY(0);
+}
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -217,13 +217,16 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <a href="#main-content" className="skip-to-content">
+          Skip to main content
+        </a>
         <Script
           src="https://umami-iamjarl.vercel.app/script.js"
           data-website-id="a8ee647d-8843-48d5-8cbc-33224e12ad61"
           strategy="afterInteractive"
         />
         <Nav />
-        {children}
+        <div id="main-content">{children}</div>
         <Footer />
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -305,14 +305,16 @@ export default function Home() {
           
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-12">
             {badges.map((badge, index) => (
-              <motion.div
+              <motion.button
                 key={badge.filename}
+                type="button"
                 initial={{ opacity: 0, y: 20 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, margin: '-50px' }}
                 transition={{ duration: 0.5, delay: index * 0.1 }}
                 whileHover={{ y: -4 }}
-                className="border border-zinc-200 dark:border-zinc-800 rounded-lg p-6 hover:border-zinc-300 dark:hover:border-zinc-700 transition-all cursor-pointer"
+                aria-label={`Open ${badge.name} badge details`}
+                className="text-left border border-zinc-200 dark:border-zinc-800 rounded-lg p-6 hover:border-zinc-300 dark:hover:border-zinc-700 transition-all cursor-pointer bg-transparent"
                 onClick={() => {
                   setSelectedBadge(badge);
                   setSelectedVariant('white');
@@ -330,7 +332,7 @@ export default function Home() {
                 </div>
                 <h3 className="font-semibold text-lg mb-2">{badge.name}</h3>
                 <p className="text-sm text-zinc-600 dark:text-zinc-400">{badge.description}</p>
-              </motion.div>
+              </motion.button>
             ))}
           </div>
 
@@ -369,9 +371,10 @@ export default function Home() {
                 </div>
 
                 {/* Variant Selector */}
-                <div className="flex gap-4 mb-6">
+                <div className="flex gap-4 mb-6" role="group" aria-label="Badge variant">
                   <button
                     onClick={() => setSelectedVariant('white')}
+                    aria-pressed={selectedVariant === 'white'}
                     className={`px-4 py-2 rounded ${
                       selectedVariant === 'white'
                         ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
@@ -382,6 +385,7 @@ export default function Home() {
                   </button>
                   <button
                     onClick={() => setSelectedVariant('black')}
+                    aria-pressed={selectedVariant === 'black'}
                     className={`px-4 py-2 rounded ${
                       selectedVariant === 'black'
                         ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
@@ -436,6 +440,10 @@ export default function Home() {
                       >
                         {copied === 'url' ? '✓ Copied!' : 'Copy Image URL'}
                       </button>
+                    </div>
+                    {/* Screen reader announcement for copy action */}
+                    <div className="sr-only" role="status" aria-live="polite">
+                      {copied ? `${copied} embed code copied to clipboard` : ''}
                     </div>
                   </div>
                 </div>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,34 +1,45 @@
+'use client';
+
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const navLinks = [
+  { href: '/about', label: 'About' },
+  { href: '/badges', label: 'Badges' },
+  { href: '/guide', label: 'Guide' },
+];
 
 export default function Nav() {
+  const pathname = usePathname();
+
   return (
-    <nav className="px-4 sm:px-6 lg:px-8 py-4">
+    <nav aria-label="Main navigation" className="px-4 sm:px-6 lg:px-8 py-4">
       <div className="max-w-6xl mx-auto flex items-center justify-between">
         <Link
           href="/"
+          aria-current={pathname === '/' ? 'page' : undefined}
           className="font-bold text-lg text-zinc-900 dark:text-zinc-50 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
         >
           Made by Human
         </Link>
         <div className="flex items-center gap-6 text-sm font-medium">
-          <Link
-            href="/about"
-            className="text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
-          >
-            About
-          </Link>
-          <Link
-            href="/badges"
-            className="text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
-          >
-            Badges
-          </Link>
-          <Link
-            href="/guide"
-            className="text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
-          >
-            Guide
-          </Link>
+          {navLinks.map((link) => {
+            const isActive = pathname === link.href;
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                aria-current={isActive ? 'page' : undefined}
+                className={`transition-colors ${
+                  isActive
+                    ? 'text-zinc-900 dark:text-zinc-100 underline underline-offset-4'
+                    : 'text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100'
+                }`}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
           <a
             href="https://github.com/JarlLyng/madebyhuman"
             target="_blank"
@@ -36,6 +47,7 @@ export default function Nav() {
             className="text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
           >
             GitHub
+            <span className="sr-only"> (opens in a new tab)</span>
           </a>
         </div>
       </div>


### PR DESCRIPTION
Closes #58

## Accessibility improvements

### Global
- Visible focus rings for keyboard users (blue, 2px, offset)
- Skip-to-content link (hidden until focused)
- Respect `prefers-reduced-motion` — animations disabled for users who prefer reduced motion
- Main content wrapped in `<div id="main-content">` for skip-link target

### Navigation
- `aria-current="page"` on active link + visual underline
- `aria-label="Main navigation"` on nav element
- Screen reader text on external GitHub link ("opens in a new tab")

### /badges page
- Variant toggles use `aria-pressed` instead of relying on visual state only
- Toggles grouped with `role="group"` + descriptive `aria-label`
- Copy buttons have descriptive `aria-label`s
- `aria-live="polite"` region announces when embed codes are copied

### Homepage
- Badge cards converted from `motion.div` to `motion.button` — now keyboard-accessible and announced as buttons by screen readers
- Modal variant toggles use `aria-pressed`
- Modal copy buttons have `aria-live` feedback region

## Content
- Added link to [Medium article](https://medium.com/@jarllyng/made-by-human-6fe8ccf0ce2f) on the /about page — gives visitors the full origin story

## Test plan
- [x] `npm run build` passes
- [ ] Tab through site with keyboard — verify focus is visible
- [ ] Test skip-to-content link (first Tab on any page)
- [ ] Test copy buttons with screen reader (should announce "copied to clipboard")