### PR TITLE
chore: add SECURITY.md, CHANGELOG, and bump to v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-04-29
+
+First public release.
+
+### Added
+
+- Four badge designs in white and black SVG variants:
+  - **Made by Human** — general badge for human creativity
+  - **Co-created with AI** — for human-AI collaboration
+  - **Crafted by Human** — for fully hand-made work
+  - **Human in the Loop** — for AI-assisted work with human oversight
+- Homepage (`/`) with hero, philosophy, badge gallery modal, and how-to-use section
+- About page (`/about`) telling the origin story and philosophy, with a link to the [Medium article](https://medium.com/@jarllyng/made-by-human-6fe8ccf0ce2f)
+- Badge gallery (`/badges`) with per-badge previews, variant selector, SVG download, and Markdown/HTML/URL embed codes
+- Step-by-step guide (`/guide`) for adding badges to GitHub READMEs and websites
+- Embed codes wrap the badge in a link back to `madebyhuman.iamjarl.com` so each adoption is also a backlink
+- JSON-LD structured data for rich search results: `WebSite`, `Organization`, `ItemList`, `FAQPage`, `BreadcrumbList`, and `HowTo`
+- `sitemap.xml` generated automatically on each deploy
+- `robots.txt` with explicit allow rules for AI crawlers (GPTBot, ClaudeBot, PerplexityBot, etc.)
+- `llms.txt` for AI engine indexing
+- Footer cross-links to other IAMJARL projects (Emotionwave, BeerTuner, Get to the Movie!, Running from Horses, TrimrPix)
+- Accessibility: skip-to-content link, visible focus rings, `aria-pressed` toggles, `aria-live` copy feedback, `aria-current` nav state, `prefers-reduced-motion` support
+- Umami analytics with custom events for badge downloads and embed copies
+- GitHub Pages deployment via GitHub Actions
+- Dependabot configuration for npm and GitHub Actions updates
+- CodeQL code scanning, secret scanning, and push protection
+- Issue templates (bug report, feature request, badge idea), PR template, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`
+
+[Unreleased]: https://github.com/JarlLyng/madebyhuman/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/JarlLyng/madebyhuman/releases/tag/v1.0.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Made by Human, please report it
+privately via [GitHub Security Advisories](https://github.com/JarlLyng/madebyhuman/security/advisories/new)
+rather than opening a public issue.
+
+We aim to respond within 7 days.
+
+## Supported Versions
+
+Only the latest version (deployed at https://madebyhuman.iamjarl.com) is
+supported. The project ships continuously from `main`.
+
+## What's in scope
+
+- The website code in this repository
+- The hosted SVG badges at `madebyhuman.iamjarl.com/badges/`
+
+## What's out of scope
+
+- Third-party services we link to (GitHub, Umami, IAMJARL projects)
+- Vulnerabilities in dependencies — please report those upstream. Dependabot
+  will pick them up here automatically.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "madebyhuman",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "scripts": {
     "dev": "next dev",
     "prebuild": "node scripts/generate-sitemap.mjs",


### PR DESCRIPTION
Closes #66
Closes #67

## Summary
- **SECURITY.md** — vulnerability reporting policy via GitHub Security Advisories (#66)
- **CHANGELOG.md** — Keep a Changelog format with full v1.0.0 entry (#67)
- **package.json** — bumped from 0.1.0 to 1.0.0

## After merge
- Tag `v1.0.0` and create GitHub release with the CHANGELOG entry as description