### PR TITLE
fix(deps): override postcss to >= 8.5.10 to fix XSS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4983,34 +4983,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "eslint-config-next": "^16.2.6",
     "tailwindcss": "^4",
     "typescript": "^6"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Summary
- Adds an `overrides` block in `package.json` pinning `postcss` to `^8.5.10`.
- Resolves Dependabot alert #21 (PostCSS XSS via unescaped `</style>` in CSS stringify output) — vulnerable range `< 8.5.10`.
- Both `next` and `@tailwindcss/postcss` transitively resolve older 8.4.x/8.5.6 versions; the override forces a single deduped 8.5.15.

## Test plan
- [x] `npm install` clean
- [x] `npm ls postcss` shows single deduped `8.5.15`
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)