### PR TITLE
docs(blog): link Medium article in welcome post

### DIFF
--- a/src/content/blog/welcome-to-the-blog.mdx
+++ b/src/content/blog/welcome-to-the-blog.mdx
@@ -8,8 +8,9 @@ tags: ["announcement"]
 
 This is the first post on the **Made by Human** blog. Expect short essays on
 human creativity in an AI-saturated world, build-in-public updates on the
-badges and the manifesto, and occasional deep dives into how creators are
-using the badge in their work.
+manifesto, and occasional deep dives into how creators are using the badge in their work.
+
+For a deeper dive into the origin of this project, you can read the original article: [Made by Human — On authenticity, intention, and why I started this project](https://medium.com/@jarllyng/made-by-human-6fe8ccf0ce2f) on Medium.
 
 If you want to be part of the movement, [grab a badge](/badges) and add it to
 your project. That's it.


### PR DESCRIPTION
Links the author's Medium article explaining the origin story of the project directly in the welcome blog post.