### PR TITLE
chore(analytics): respect DNT, scope to prod domain, env-configure Umami + RSS discoverability

### DIFF
--- a/public/rss.xml
+++ b/public/rss.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://madebyhuman.iamjarl.com/rss.xml" rel="self" type="application/rss+xml" />
     <description>Essays and updates on human creativity in an AI-saturated world.</description>
     <language>en</language>
-    <lastBuildDate>Fri, 22 May 2026 22:09:19 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 22 May 2026 23:02:46 GMT</lastBuildDate>
     <item>
       <title>How to Add a 'Made by Human' Badge to Your Next.js or React Website</title>
       <link>https://madebyhuman.iamjarl.com/blog/how-to-add-badge-to-nextjs-react</link>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -61,8 +61,16 @@ export default function BlogIndexPage() {
           <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight mb-6">
             Blog
           </h1>
-          <p className="text-xl text-zinc-600 dark:text-zinc-400 font-light mb-16">
+          <p className="text-xl text-zinc-600 dark:text-zinc-400 font-light mb-6">
             Essays and updates on human creativity in an AI-saturated world.
+          </p>
+          <p className="mb-16">
+            <a
+              href="/rss.xml"
+              className="text-sm font-medium text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 underline underline-offset-4 transition-colors"
+            >
+              Subscribe via RSS →
+            </a>
           </p>
 
           {posts.length === 0 ? (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,6 +40,9 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: `${baseUrl}/`,
+    types: {
+      'application/rss+xml': `${baseUrl}/rss.xml`,
+    },
   },
   icons: {
     icon: [
@@ -221,8 +224,13 @@ export default function RootLayout({
           Skip to main content
         </a>
         <Script
-          src="https://umami-iamjarl.vercel.app/script.js"
-          data-website-id="a8ee647d-8843-48d5-8cbc-33224e12ad61"
+          src={process.env.NEXT_PUBLIC_UMAMI_SRC || 'https://umami-iamjarl.vercel.app/script.js'}
+          data-website-id={
+            process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID ||
+            'a8ee647d-8843-48d5-8cbc-33224e12ad61'
+          }
+          data-domains="madebyhuman.iamjarl.com"
+          data-do-not-track="true"
           strategy="afterInteractive"
         />
         <Nav />


### PR DESCRIPTION
## Summary

### Privacy + correctness for Umami
- **\`data-do-not-track=\"true\"\`** — Umami now honors the browser's Do Not Track signal. For a project whose premise is transparency and human agency, this matters principled-ly.
- **\`data-domains=\"madebyhuman.iamjarl.com\"\`** — analytics ignores traffic from localhost, PR previews, and forks. No more polluted production data from dev sessions.
- **Env-configurable** — \`NEXT_PUBLIC_UMAMI_SRC\` and \`NEXT_PUBLIC_UMAMI_WEBSITE_ID\` with current values as fallbacks. Forks and stagings no longer need to edit code.
- **\`.env.example\`** added documenting all \`NEXT_PUBLIC_*\` variables.

### RSS discoverability
- \`<link rel=\"alternate\" type=\"application/rss+xml\">\` in \`<head>\` via Next metadata so feed readers auto-discover \`/rss.xml\`.
- Visible \"Subscribe via RSS →\" link in the blog index header.

## Test plan
- [x] \`npm run build\` succeeds — all 13 static pages
- [x] \`out/index.html\` contains \`data-do-not-track\`, \`data-domains\`, and \`rss+xml\` alternate link
- [x] \`out/blog.html\` contains \"Subscribe via RSS\"
- [ ] Verify on deploy that Umami stops counting localhost visits

🤖 Generated with [Claude Code](https://claude.com/claude-code)