### PR TITLE
chore(seo): rewrite /badges metadata for higher CTR

### DIFF
--- a/public/rss.xml
+++ b/public/rss.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://madebyhuman.iamjarl.com/rss.xml" rel="self" type="application/rss+xml" />
     <description>Essays and updates on human creativity in an AI-saturated world.</description>
     <language>en</language>
-    <lastBuildDate>Fri, 22 May 2026 23:02:46 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 04 Jun 2026 06:37:12 GMT</lastBuildDate>
     <item>
       <title>How to Add a 'Made by Human' Badge to Your Next.js or React Website</title>
       <link>https://madebyhuman.iamjarl.com/blog/how-to-add-badge-to-nextjs-react</link>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://madebyhuman.iamjarl.com/</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://madebyhuman.iamjarl.com/about</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-06-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://madebyhuman.iamjarl.com/badges</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://madebyhuman.iamjarl.com/guide</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-06-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://madebyhuman.iamjarl.com/blog</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/app/badges/layout.tsx
+++ b/src/app/badges/layout.tsx
@@ -4,16 +4,16 @@ import { getBaseUrl } from '../config';
 const baseUrl = getBaseUrl();
 
 export const metadata: Metadata = {
-  title: 'Free Transparency Badges for GitHub & Websites - Made by Human',
+  title: 'Made by Human Badges — Free SVG, Copy-Paste in 30s',
   description:
-    'Download free SVG badges to mark human creativity and AI collaboration in your projects. Made by Human, Co-created with AI, Crafted by Human, and Human in the Loop — for GitHub READMEs, websites, and portfolios.',
+    'Four free SVG badges (light + dark) for GitHub READMEs and websites — Made by Human, Co-created with AI, Crafted by Human, Human in the Loop. MIT licensed.',
   alternates: {
     canonical: `${baseUrl}/badges`,
   },
   openGraph: {
-    title: 'Free Transparency Badges - Made by Human',
+    title: 'Made by Human Badges — Free, open-source SVG',
     description:
-      'Download free SVG badges to mark human creativity and AI collaboration. For GitHub READMEs, websites, and portfolios.',
+      'Free SVG badges that signal human creativity and intentional AI collaboration. Pick the badge that matches how you build.',
     url: `${baseUrl}/badges`,
   },
 };


### PR DESCRIPTION
## Why

GSC (last 28 days) shows `/badges` on page 1 — average position **6.4** — but with **0% CTR** over 22 impressions. The page is being shown to searchers; they're just not clicking. The previous metadata was the most likely culprit: verbose, with the actionable details buried beyond Google's snippet limit.

## What

### Title
- before: \`Free Transparency Badges for GitHub & Websites - Made by Human\` (62 chars)
- after: \`Made by Human Badges — Free SVG, Copy-Paste in 30s\` (51 chars)

Reasoning: leads with the brand keyword (highest-converting query from GSC: \"made by humans badge\" — 1 click, position 4.9), keeps within Google's title truncation, swaps the abstract \"transparency badges\" framing for a concrete action (\"copy-paste in 30s\") that signals low effort.

### Description
- before: 213 chars — Google truncates around 155–160, so \"...for GitHub READMEs, websites, and portfolios\" never showed in results.
- after: 155 chars — stays inside the snippet limit, leads with quantity and price (\"four free\"), keeps all four badge names for tail-keyword matches (\"co-created with AI\", \"crafted by human\", \"human in the loop\"), ends with the license signal.

### OpenGraph
Also tightened for clearer social-share previews.

## Test plan
- [x] \`npm run build\` succeeds — all routes still rendering
- [ ] After merge + deploy, request re-indexing in GSC and watch CTR on /badges over the next 2 weeks

🤖 Generated with [Claude Code](https://claude.com/claude-code)