### PR TITLE
feat(blog): add Related Posts section for internal link density

### DIFF
--- a/public/rss.xml
+++ b/public/rss.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://madebyhuman.iamjarl.com/rss.xml" rel="self" type="application/rss+xml" />
     <description>Essays and updates on human creativity in an AI-saturated world.</description>
     <language>en</language>
-    <lastBuildDate>Thu, 04 Jun 2026 06:37:12 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 11 Jun 2026 22:08:00 GMT</lastBuildDate>
     <item>
       <title>How to Add a 'Made by Human' Badge to Your Next.js or React Website</title>
       <link>https://madebyhuman.iamjarl.com/blog/how-to-add-badge-to-nextjs-react</link>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://madebyhuman.iamjarl.com/</loc>
-    <lastmod>2026-06-04</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://madebyhuman.iamjarl.com/about</loc>
-    <lastmod>2026-06-04</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://madebyhuman.iamjarl.com/badges</loc>
-    <lastmod>2026-06-04</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://madebyhuman.iamjarl.com/guide</loc>
-    <lastmod>2026-06-04</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://madebyhuman.iamjarl.com/blog</loc>
-    <lastmod>2026-06-04</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { MDXRemote } from 'next-mdx-remote/rsc';
-import { getPost, listPostSlugs } from '@/lib/posts';
+import { getPost, getRelatedPosts, listPostSlugs } from '@/lib/posts';
 import { getBaseUrl } from '../../config';
 
 const baseUrl = getBaseUrl();
@@ -155,6 +155,62 @@ export default async function BlogPostPage({
           </div>
         </div>
       </article>
+
+      <RelatedPosts slug={post.slug} />
     </main>
+  );
+}
+
+function RelatedPosts({ slug }: { slug: string }) {
+  const related = getRelatedPosts(slug, 3);
+  if (related.length === 0) return null;
+
+  return (
+    <aside
+      aria-label="Related posts"
+      className="px-4 sm:px-6 lg:px-8 py-16 sm:py-20 bg-zinc-50 dark:bg-zinc-900 border-t border-zinc-200 dark:border-zinc-800"
+    >
+      <div className="max-w-6xl mx-auto">
+        <div className="flex items-end justify-between mb-10 flex-wrap gap-4">
+          <div>
+            <p className="text-sm uppercase tracking-wide text-zinc-500 dark:text-zinc-400 mb-2">
+              Keep reading
+            </p>
+            <h2 className="text-2xl sm:text-3xl font-bold tracking-tight">
+              Related posts
+            </h2>
+          </div>
+          <Link
+            href="/blog"
+            className="text-sm font-medium text-zinc-900 dark:text-zinc-100 underline underline-offset-4 hover:text-zinc-600 dark:hover:text-zinc-400 transition-colors"
+          >
+            All posts →
+          </Link>
+        </div>
+
+        <ul className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          {related.map((post) => (
+            <li key={post.slug}>
+              <article className="h-full">
+                <Link href={`/blog/${post.slug}`} className="group block h-full">
+                  <time
+                    dateTime={post.date}
+                    className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400"
+                  >
+                    {formatDate(post.date)}
+                  </time>
+                  <h3 className="text-xl font-bold mt-2 mb-3 group-hover:text-zinc-600 dark:group-hover:text-zinc-300 transition-colors">
+                    {post.title}
+                  </h3>
+                  <p className="text-base text-zinc-600 dark:text-zinc-400 line-clamp-3">
+                    {post.description}
+                  </p>
+                </Link>
+              </article>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
   );
 }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -46,3 +46,21 @@ export function listPosts(): PostMeta[] {
     })
     .sort((a, b) => (a.date < b.date ? 1 : -1));
 }
+
+export function getRelatedPosts(slug: string, limit = 3): PostMeta[] {
+  const current = getPost(slug);
+  const currentTags = new Set(current.tags ?? []);
+  const others = listPosts().filter((p) => p.slug !== slug);
+
+  const scored = others.map((p) => ({
+    post: p,
+    shared: (p.tags ?? []).filter((t) => currentTags.has(t)).length,
+  }));
+
+  scored.sort((a, b) => {
+    if (b.shared !== a.shared) return b.shared - a.shared;
+    return a.post.date < b.post.date ? 1 : -1;
+  });
+
+  return scored.slice(0, limit).map((s) => s.post);
+}


### PR DESCRIPTION
## Why

GSC URL inspection (2026-06-12) shows 5 of 6 blog URLs are stuck in **\"Discovered – currently not indexed\"**. Google knows about them from \`sitemap.xml\` but hasn't allocated crawl budget yet. The setup is technically correct (HTML is statically pre-rendered, links resolve, the one indexed post \`why-ai-transparency-matters\` got rich results) — Google just isn't crawling fast enough.

Internal link density is one of the few inputs we control that influences this decision. Previously each post had exactly **one** outgoing internal link (\`← Back to blog\`). Now each post links out to 3 related posts, so every post has ~4 outgoing internal links.

## How

- \`src/lib/posts.ts\` gains \`getRelatedPosts(slug, limit)\`. Scoring is tag-overlap first, then recency — so guide posts cluster with guide posts, philosophy posts cluster with philosophy posts, and tag-less situations fall back to most-recent.
- \`src/app/blog/[slug]/page.tsx\` renders a \`<RelatedPosts />\` server component at the bottom of every post: \"Keep reading / Related posts\" headline, all-posts link, three cards.

## Side benefits beyond crawlability
- Stronger topical clustering signal to Google.
- Reader can stay on-site beyond a single post — engagement signal.
- Visual / UX upgrade — posts no longer feel like dead ends.

## Test plan
- [x] \`npm run build\` succeeds — all 6 post pages render
- [x] Verified in \`out/blog/art-of-curation-human-touch.html\`: 3 related links to other tagged-philosophy posts
- [x] Verified in \`out/blog/how-to-add-badge-to-nextjs-react.html\`: 3 related links (tag overlap + recency)
- [x] Verified in \`out/blog/welcome-to-the-blog.html\`: 3 related links (fallback to recency since the announcement tag is unique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)