### PR TITLE
feat(footer): add WODrounds and Anvil Workout cross-links

### DIFF
--- a/public/rss.xml
+++ b/public/rss.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://madebyhuman.iamjarl.com/rss.xml" rel="self" type="application/rss+xml" />
     <description>Essays and updates on human creativity in an AI-saturated world.</description>
     <language>en</language>
-    <lastBuildDate>Thu, 11 Jun 2026 22:08:00 GMT</lastBuildDate>
+    <lastBuildDate>Sat, 11 Jul 2026 22:35:16 GMT</lastBuildDate>
     <item>
       <title>How to Add a 'Made by Human' Badge to Your Next.js or React Website</title>
       <link>https://madebyhuman.iamjarl.com/blog/how-to-add-badge-to-nextjs-react</link>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://madebyhuman.iamjarl.com/</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-07-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://madebyhuman.iamjarl.com/about</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-07-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://madebyhuman.iamjarl.com/badges</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-07-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://madebyhuman.iamjarl.com/guide</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-07-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://madebyhuman.iamjarl.com/blog</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-07-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -43,6 +43,15 @@ export default function Footer() {
             </a>
             <span className="text-zinc-300 dark:text-zinc-700">&middot;</span>
             <a
+              href="https://anvilworkout.iamjarl.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+            >
+              Anvil Workout
+            </a>
+            <span className="text-zinc-300 dark:text-zinc-700">&middot;</span>
+            <a
               href="https://emotionwave.iamjarl.com/"
               target="_blank"
               rel="noopener noreferrer"
@@ -85,6 +94,15 @@ export default function Footer() {
               className="text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
             >
               TrimrPix
+            </a>
+            <span className="text-zinc-300 dark:text-zinc-700">&middot;</span>
+            <a
+              href="https://wodrounds.iamjarl.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+            >
+              WODrounds
             </a>
             <span className="text-zinc-300 dark:text-zinc-700">&middot;</span>
             <a


### PR DESCRIPTION
## Summary
Adds \`anvilworkout.iamjarl.com\` and \`wodrounds.iamjarl.com\` to the footer's IAMJARL portfolio cross-links row. Both were missing; every other paid native app in the portfolio was already listed.

Made by Human is a top-of-funnel entry point for the portfolio, so keeping the paid native apps discoverable from the footer is a permanent, cheap, SEO-positive backlink into them.

Ordering stays roughly alphabetical: IAMJARL · Anvil Workout · Emotionwave · BeerTuner · Get to the Movie! · Running from Horses · TrimrPix · WODrounds · GitHub.

## Test plan
- [x] \`npm run build\` succeeds
- [x] Verified both URLs present in the rendered \`out/index.html\`
- [ ] After deploy, spot-check the footer on the live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)